### PR TITLE
Update popup content automatically

### DIFF
--- a/packages/ember-leaflet/lib/mixin/popup.js
+++ b/packages/ember-leaflet/lib/mixin/popup.js
@@ -66,6 +66,11 @@ EmberLeaflet.PopupMixin = Ember.Mixin.create({
     this.didDestroyPopup();
   },
 
+  _updatePopup: Ember.observer(function() {
+    if(!this._popup) { return; }
+    this._popup.setContent(get(this, 'popupContent'));
+  }, 'popupContent'),
+
   _removePopupObservers: Ember.beforeObserver(function() {
     if(!this._layer) { return; }
     this._destroyPopup();

--- a/packages/ember-leaflet/tests/mixin/marker_popup_tests.js
+++ b/packages/ember-leaflet/tests/mixin/marker_popup_tests.js
@@ -2,7 +2,9 @@ require('ember-leaflet/~tests/test_helper');
 
 var marker, MarkerClass, view, 
   locationsEqual = window.locationsEqual,
-  locations = window.locations;
+  locations = window.locations,
+  firstPopupContent = 'hello there!',
+  secondPopupContent = 'salutations!';
 
 var get = Ember.get;
 
@@ -13,7 +15,7 @@ module("EmberLeaflet.PopupMixin (Marker)", {
     
     marker = MarkerClass.create({
       content: {location: locations.nyc},
-      popupContent: 'hello there!'
+      popupContent: firstPopupContent
     });
 
     view = EmberLeaflet.MapView.create({childLayers: [marker]});
@@ -36,8 +38,15 @@ test("Popup is created", function() {
 test("Clicking shows popup", function() {
   marker._layer.fire('click', {latlng: marker.get('location')});
   ok(!!marker._popup._map, "marker added to map");
-  equal(marker._popup._content, 'hello there!');
+  equal(marker._popup._content, firstPopupContent, "popup content set");
   locationsEqual(marker._popup._latlng, marker.get('location'));
+});
+
+test("Popup content updates", function() {
+  marker._layer.fire('click', {latlng: marker.get('location')});
+  equal(marker._popup._content, firstPopupContent, "popup content initially set");
+  marker.set('popupContent', secondPopupContent);
+  equal(marker._popup._content, secondPopupContent, "popup content updates");
 });
 
 test("Destroying map destroys popup", function() {


### PR DESCRIPTION
Recently, I linked some popups to dynamic data. I noticed it was necessary to close and reopen a popup in order to update its content. I thought, "we can do better than this." As it turns out we can, and it's pretty easy too.

Popups now automatically update when their backing content changes.
A test for this is included as well.
