### PR TITLE
Delay tolerant computed styleProperty

### DIFF
--- a/packages/ember-leaflet/tests/utils_tests.js
+++ b/packages/ember-leaflet/tests/utils_tests.js
@@ -126,3 +126,10 @@ test("Setters", function() {
   layer.set('pointerEvents', 'none');
   equal(layer._layer.options.pointerEvents, 'none', "set pointer events");
 });
+
+test("Postponed set operations propegate to layer", function() {
+  layer._destroyLayer();
+  layer.set('color', '#000');
+  layer._createLayer();
+  equal(layer._layer.options.color, '#000', "set after layer re-creation");
+});


### PR DESCRIPTION
If the layer does not exist, propagate style changes to the layer once it exists.

This way of working could also be applied to `optionProperty`.

It enables layers be deleted and re-created later without worrying about intermediate style changes "vanishing".

Overall, EmberLeaflet could use more consistent (and graceful) handling of non-existent layers, locations, etc. As a side effect, changes while a layer doesn't exist should either be ignored or applied to the layer once it exists. This is in support of the latter, but I'm interested in hearing other opinions too.

_P.S._ Locally, I've re-written `PolylineLayer` to destroy the layer if `locations.length` is 0 or `undefined`, and re-create it once there are locations again. This was due to an overlay I was placing on the layer not disappearing when I set the content to an empty array, and EmberLeaflet threw errors when I un-set the content (set it to `undefined`). This is an example of where I think EmberLeaflet can improve on handling objects that may or may not exist upon execution.

I could create a pull request for my `PolylineLayer` edits too, but I thought I'd start the conversation here. `computed.styleProperty` was the deepest level from which errors were emanating.
