### PR TITLE
Fix popupopen and popupclose events

### DIFF
--- a/packages/ember-leaflet/lib/mixin/popup.js
+++ b/packages/ember-leaflet/lib/mixin/popup.js
@@ -53,7 +53,7 @@ EmberLeaflet.PopupMixin = Ember.Mixin.create({
 
   _createPopup: function() {
     this.willCreatePopup();
-    this._popup = L.popup(this.get('popupOptions'));
+    this._popup = L.popup(this.get('popupOptions'),this._layer);
     this.didCreatePopup();
   },
 


### PR DESCRIPTION
This fixes the problem I mention here:
https://github.com/gabesmed/ember-leaflet/issues/30#issuecomment-42209929

Added source layer in popup creation. Now `popupopen` and `popupclose` events are properly executed in the source layers.
