### PR TITLE
Update MapView centerDidChange

### DIFF
--- a/packages/ember-leaflet/lib/map.js
+++ b/packages/ember-leaflet/lib/map.js
@@ -112,6 +112,8 @@ EmberLeaflet.MapView = Ember.View.extend(EmberLeaflet.ContainerLayerMixin, {
   centerDidChange: Ember.observer(function() {
     if (!this._layer || this.get('isMoving') ||
       !this.get('center')) { return; }
-    this._layer.panTo(this.get('center'));
+    if (!this._layer.getCenter().equals(this.get('center'))) {
+      this._layer.panTo(this.get('center'));
+    }
   }, 'center')
 });


### PR DESCRIPTION
Ran into infinite loop with centerDidChange panning to center which triggered move. Move set the center and then centerDidChange was triggered and so on.

Now I just check if the map is already at the center. If so, there is no reason to pan.
