### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "VERSION"
   ],
   "dependencies": {
-    "ember": "~1.5",
+    "ember": "^1.5",
     "leaflet-dist": "~0.7.0",
     "leaflet.markerclusterer": "0.4"
   }


### PR DESCRIPTION
Any reason we can't make this `^1.5` (and use e.g. ember 1.7)?
