### PR TITLE
Initialize L.Icon.Default.imagePath

### DIFF
--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -31,6 +31,7 @@ export default Ember.Component.extend(ContainerLayerMixin, {
     'locationerror', 'popupopen', 'popupclose'],
 
   init: function() {
+    L.Icon.Default.imagePath = 'assets/images';
     this._super();
     if(this.get('childLayers') === undefined) {
       this.set('childLayers', [DefaultTileLayer]);


### PR DESCRIPTION
This PR prevents Leaflet from failing to detect `L.Icon.Default.imagePath`. As of now, usage of markers (e.g. via MarkerCollectionLayer) will fail with:

    Couldn't autodetect L.Icon.Default.imagePath, set it manually.
This is because the way the library is loaded prevents it from detecting the path correctly (see here for further details: http://stackoverflow.com/a/14703995/2637573).