### PR TITLE
Fix ember 1.12 deprecations

### DIFF
--- a/addon/mixins/layer.js
+++ b/addon/mixins/layer.js
@@ -37,14 +37,14 @@ export default Ember.Mixin.create({
   */
   parentLayer: Ember.computed.alias('_parentLayer').readOnly(),
 
-  layer: Ember.computed(function() { return this._layer; }).property(),
+  layer: Ember.computed(function() { return this._layer; }),
 
   /**
    Create and return the layer instance for the view.
    This needs to be implemented for any new type of view.
    @protected
   */
-  _newLayer: Ember.required(Function),
+  _newLayer: null,
 
   /**
    This gets called by the view just before the layer is created.

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -1,37 +1,46 @@
 import Ember from 'ember';
 import convert from './convert';
+import computed from 'ember-new-computed';
 
 var get = Ember.get, set = Ember.set;
 
-var computed = {};
+var computedProperties = {};
 
 /**
   Define a computed property that gets and sets a value from the
   options object.
   @method optionProperty
 */
-computed.optionProperty = function(optionKey) {
-  return Ember.computed('options', function(key, value) {
-    // override given key with explicitly defined one if necessary
-    key = optionKey || key;
-    if(arguments.length > 1) { // set
+computedProperties.optionProperty = function(optionKey) {
+  return computed('options', {
+    get(key) {
+      // override given key with explicitly defined one if necessary
+      key = optionKey || key;
+      return this._layer.options[key];
+    },
+    set(key, value) {
+      // override given key with explicitly defined one if necessary
+      key = optionKey || key;
       var setterName = 'set' + Ember.String.classify(key);
       Ember.assert(
         this.constructor + " must have a " + setterName + " function.",
         !!this._layer[setterName]);
       this._layer[setterName].call(this._layer, value);
       return value;
-    } else { // get
-      return this._layer.options[key];
     }
   });
 };
 
-computed.pathStyleProperty = function(styleKey) {
-  return Ember.computed('options', function(key, value) {
-    // override given key with explicitly defined one if necessary
-    key = styleKey || key;
-    if(arguments.length > 1) { // set
+computedProperties.pathStyleProperty = function(styleKey) {
+  return computed('options', {
+    get(key) {
+      // override given key with explicitly defined one if necessary
+      key = styleKey || key;
+      return this._layer.options[key];
+    },
+    set(key, value) {
+      // override given key with explicitly defined one if necessary
+      key = styleKey || key;
       // Update style on existing object
       if(this._layer) {
         var styleObject = {};
@@ -42,8 +51,6 @@ computed.pathStyleProperty = function(styleKey) {
       if(!get(this, 'options')) { set(this, 'options', {}); }
       this.get('options')[key] = value;
       return value;
-    } else { // get
-      return this._layer.options[key];
     }
   });
 };
@@ -53,11 +60,12 @@ computed.pathStyleProperty = function(styleKey) {
   to a leaflet LatLng object.
   @method latlngFromLngLatArray
 */
-computed.latLngFromLngLatArray = function(coordKey) {
-  return Ember.computed(coordKey, function(key, value) {
-    if(arguments.length === 1) {
+computedProperties.latLngFromLngLatArray = function(coordKey) {
+  return computed(coordKey, {
+    get() {
       return convert.latLngFromLngLatArray(get(this, coordKey));
-    } else {
+    },
+    set(key, value) {
       set(this, coordKey, convert.lngLatArrayFromLatLng(value));
       return value;
     }
@@ -69,15 +77,16 @@ computed.latLngFromLngLatArray = function(coordKey) {
   to a leaflet LatLng object.
   @method latlngFromLatLngArray
 */
-computed.latLngFromLatLngArray = function(coordKey) {
-  return Ember.computed(coordKey, function(key, value) {
-    if(arguments.length === 1) {
+computedProperties.latLngFromLatLngArray = function(coordKey) {
+  return computed(coordKey, {
+    get() {
       return convert.latLngFromLatLngArray(get(this, coordKey));
-    } else {
+    },
+    set(key, value) {
       set(this, coordKey, value = convert.latLngArrayFromLatLng(value));
       return value;
     }
   });
 };
 
-export default computed;
+export default computedProperties;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-yuidoc": "0.6.2",
     "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-new-computed": "1.0.0",
     "ember-try": "0.0.4"
   },
   "keywords": [


### PR DESCRIPTION
This makes some minor adjustments for Ember 1.12, introduced with Ember CLI 0.2.4. The new get/set code is a breaking change, which will not work in Ember CLI < 0.2.4. So it is probably best to not merge this immediately.