### PR TITLE
fix deprecation warning in ember 1.13.5

### DIFF
--- a/addon/components/leaflet-map.js
+++ b/addon/components/leaflet-map.js
@@ -103,20 +103,20 @@ export default Ember.Component.extend(ContainerLayerMixin, {
     this.set('center', this._layer.getCenter());
   },
 
-  zoomDidChange: Ember.observer(function() {
+  zoomDidChange: Ember.observer('zoom', function() {
     if(!this._layer || Ember.isNone(this.get('zoom'))) { return; }
     if(this._layer._animatingZoom) {
       this._queuedZoom = this.get('zoom');
     } else {
       this._layer.setZoom(this.get('zoom'));
     }
-  }, 'zoom'),
+  }),
 
-  centerDidChange: Ember.observer(function() {
+  centerDidChange: Ember.observer('center', function() {
     if (!this._layer || this.get('isMoving') ||
       !this.get('center')) { return; }
     if (!this._layer.getCenter().equals(this.get('center'))) {
       this._layer.panTo(this.get('center'));
     }
-  }, 'center')
+  })
 });

--- a/addon/layers/array-path.js
+++ b/addon/layers/array-path.js
@@ -55,15 +55,15 @@ export default PathLayer.extend({
     return locations;
   }).property('content', 'locationProperty', 'locationsProperty').volatile(),
 
-  _contentWillChange: Ember.beforeObserver(function() {
+  _contentWillChange: Ember.beforeObserver('content', 'locationsProperty', 'locationProperty', function() {
     this._contentLocationsWillChange();
     this._teardownLocationObservers();
-  }, 'content', 'locationsProperty', 'locationProperty'),
+  }),
 
-  _contentDidChange: Ember.observer(function() {
+  _contentDidChange: Ember.observer('content', 'locationsProperty', 'locationProperty', function() {
     this._setupLocationObservers();
     this._contentLocationsDidChange();
-  }, 'content', 'locationsProperty', 'locationProperty'),
+  }),
 
   _setupLocationObservers: function() {
     var content = get(this, 'content'),
@@ -144,7 +144,7 @@ export default PathLayer.extend({
   arrayWillChange: function() {
     this.propertyWillChange('locations');
   },
-  
+
   // arrayDidChange(array, idx, removedCount, addedCount)
   arrayDidChange: function() {
     this.propertyDidChange('locations');

--- a/addon/layers/circle.js
+++ b/addon/layers/circle.js
@@ -20,7 +20,7 @@ export default PointPathLayer.extend({
   */
   radius: Ember.computed.alias('content.radius'),
 
-  _updateLayerOnRadiusChange: Ember.observer(function() {
+  _updateLayerOnRadiusChange: Ember.observer('radius', function() {
     var newRadius = get(this, 'radius');
 
     if(newRadius && !this._layer) {
@@ -33,7 +33,7 @@ export default PointPathLayer.extend({
         this._layer.setRadius(newRadius);
       }
     }
-  }, 'radius'),
+  }),
 
   _newLayer: function() {
     // Convert from array if an array somehow got through.

--- a/addon/layers/collection.js
+++ b/addon/layers/collection.js
@@ -29,19 +29,19 @@ export default ContainerLayer.extend({
     this._super();
   },
 
-  _contentWillChange: Ember.beforeObserver(function() {
+  _contentWillChange: Ember.beforeObserver('content', function() {
     var content = get(this, 'content');
     if(content) { content.removeArrayObserver(this); }
     var len = content ? get(content, 'length') : 0;
     this.arrayWillChange(content, 0, len);
-  }, 'content'),
+  }),
 
-  _contentDidChange: Ember.observer(function() {
+  _contentDidChange: Ember.observer('content', function() {
     var content = get(this, 'content');
     if(content) { content.addArrayObserver(this); }
     var len = content ? get(content, 'length') : 0;
     this.arrayDidChange(content, 0, null, len);
-  }, 'content'),
+  }),
 
   arrayWillChange: function(array, idx, removedCount) {
     for(var i = idx; i < idx + removedCount; i++) {

--- a/addon/layers/marker.js
+++ b/addon/layers/marker.js
@@ -42,7 +42,7 @@ export default Layer.extend({
     return false;
   },
 
-  _updateLayerOnLocationChange: Ember.observer(function() {
+  _updateLayerOnLocationChange: Ember.observer('location', function() {
     var newLatLng = get(this, 'location');
     if(newLatLng && !this._layer) {
       this._createLayer();
@@ -59,7 +59,7 @@ export default Layer.extend({
         }
       }
     }
-  }, 'location'),
+  }),
 
   _newLayer: function() {
     return L.marker(get(this, 'location'), get(this, 'options'));

--- a/addon/layers/point.js
+++ b/addon/layers/point.js
@@ -21,7 +21,7 @@ export default PathLayer.extend({
     this._super();
   },
 
-  _updateLayerOnLocationChange: Ember.observer(function() {
+  _updateLayerOnLocationChange: Ember.observer('location', function() {
     var newLatLng = convert.latLngFromLatLngArray(get(this, 'location'));
     if(newLatLng && !this._layer) {
       this._createLayer();
@@ -33,5 +33,5 @@ export default PathLayer.extend({
         this._layer.setLatLng(newLatLng);
       }
     }
-  }, 'location')
+  })
 });

--- a/addon/layers/polyline.js
+++ b/addon/layers/polyline.js
@@ -20,8 +20,8 @@ export default ArrayPathLayer.extend({
     return L.polyline(get(this, 'locations'), get(this, 'options'));
   },
 
-  locationsDidChange: Ember.observer(function() {
+  locationsDidChange: Ember.observer('locations', function() {
     if(!this._layer) { return; }
     this._layer.setLatLngs(get(this, 'locations'));
-  }, 'locations')
+  })
 });

--- a/addon/layers/rectangle.js
+++ b/addon/layers/rectangle.js
@@ -26,7 +26,7 @@ export default ArrayPathLayer.extend(BoundsMixin, {
     this._super();
   },
 
-  boundsDidChange: Ember.observer(function() {
+  boundsDidChange: Ember.observer('locations', function() {
     var bounds = get(this, 'bounds');
     if(this._layer && !bounds) {
       this._destroyLayer();
@@ -35,5 +35,5 @@ export default ArrayPathLayer.extend(BoundsMixin, {
     } else if(bounds && this._layer) {
       this._layer.setBounds(bounds);
     }
-  }, 'locations')
+  })
 });

--- a/addon/layers/tile.js
+++ b/addon/layers/tile.js
@@ -18,10 +18,10 @@ export default Layer.extend({
     return L.tileLayer(get(this, 'tileUrl'), get(this, 'options'));
   },
 
-  tileUrlDidChange: Ember.observer(function() {
+  tileUrlDidChange: Ember.observer('tileUrl', function() {
     if(!this._layer) { return; }
     this._layer.setUrl(this.get('tileUrl'));
-  }, 'tileUrl'),
+  }),
 
   zIndex: computed.optionProperty(),
   opacity: computed.optionProperty()

--- a/addon/mixins/draggable.js
+++ b/addon/mixins/draggable.js
@@ -24,12 +24,12 @@ export default Ember.Mixin.create({
     });
   },
 
-  _updateDraggability: Ember.observer(function() {
+  _updateDraggability: Ember.observer('isDraggable', 'layer', function() {
     if(!this._layer || !this._layer._map) { return; }
     if(get(this, 'isDraggable')) {
       this._layer.dragging.enable();
     } else {
       this._layer.dragging.disable();
     }
-  }, 'isDraggable', 'layer')
+  })
 });

--- a/addon/mixins/popup.js
+++ b/addon/mixins/popup.js
@@ -116,18 +116,18 @@ export default Ember.Mixin.create({
     this.didDestroyPopup();
   },
 
-  _updatePopup: Ember.observer(function() {
+  _updatePopup: Ember.observer('popupContent', function() {
     if(!this._popup) { return; }
     this._popup.setContent(get(this, 'popupContent'));
-  }, 'popupContent'),
+  }),
 
   _removePopupObservers: Ember.beforeObserver(function() {
     if(!this._layer) { return; }
     this._destroyPopup();
   }, 'layer'),
 
-  _addPopupObservers: Ember.observer(function() {
+  _addPopupObservers: Ember.observer('layer', function() {
     if(!this._layer) { return; }
     this._createPopup();
-  }, 'layer')
+  })
 });


### PR DESCRIPTION
DEPRECATION: Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument.