### PR TITLE
Dependecies update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,21 @@ cache:
   directories:
     - node_modules
 
+env:
+  matrix:
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.13.8
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
 before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"
@@ -19,4 +34,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try $EMBER_TRY_SCENARIO test

--- a/addon/utils/computed.js
+++ b/addon/utils/computed.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import convert from './convert';
-import computed from 'ember-new-computed';
 
 var get = Ember.get, set = Ember.set;
+var computed = Ember.computed;
 
 var computedProperties = {};
 

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,18 @@
 {
   "name": "ember-leaflet",
   "dependencies": {
-    "ember": "1.13.8",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember": "1.13.10",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",
     "ember-data": "1.13.13",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.1",
-    "ember-qunit-notifications": "0.0.7",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
+    "ember-qunit": "0.4.10",
+    "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
     "leaflet": "~0.7.3",
     "leaflet.markercluster": "~0.4.0",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "loader.js": "ember-cli/loader.js#3.3.0",
+    "qunit": "~1.19.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,45 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: 'ember-1.13.8',
+      dependencies: {
+        'ember': '1.13.8',
+        'ember-data': '1.13.9'
+      }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release',
+        'ember-data': 'v2.0.0-beta.2'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta',
+        'ember-data': 'v2.0.0-beta.2'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary',
+        'ember-data': 'v2.0.0-beta.2'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -25,26 +25,24 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
+    "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.3.3",
+    "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
-    "ember-cli-ic-ajax": "0.1.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.10",
-    "ember-cli-uglify": "1.0.1",
-    "ember-export-application-global": "^1.0.2",
+    "ember-cli-dependency-checker": "^1.1.0",
+    "ember-cli-htmlbars": "^1.0.0",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.1",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.4"
+    "ember-try": "0.0.8"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0",
-    "ember-new-computed": "1.0.0"
+    "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
also allows ember beta failure on Travis and defines ember-try scenarios.