### PR TITLE
pass at ember2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,7 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
+  allow_failures: []
 
 before_install:
   - "npm config set spin false"

--- a/addon/layers/array-path.js
+++ b/addon/layers/array-path.js
@@ -61,12 +61,12 @@ export default PathLayer.extend({
   }),
 
   _setupLocationObservers() {
-    var content = get(this, 'content'),
+    const content = get(this, 'content'),
       locationProperty = get(this, 'locationProperty'),
       locationsProperty = get(this, 'locationsProperty');
     if(!content) { return; }
 
-    var observers = [];
+    const observers = [];
 
     // Add observer on locations property of content if relevant.
     if (locationsProperty) {

--- a/addon/layers/collection.js
+++ b/addon/layers/collection.js
@@ -25,23 +25,26 @@ export default ContainerLayer.extend({
   },
 
   willDestroyLayer: function() {
-    this._contentWillChange();
+    this._clear();
     this._super();
   },
 
-  _contentWillChange: Ember.beforeObserver('content', function() {
-    var content = get(this, 'content');
-    if(content) { content.removeArrayObserver(this); }
-    var len = content ? get(content, 'length') : 0;
-    this.arrayWillChange(content, 0, len);
-  }),
-
   _contentDidChange: Ember.observer('content', function() {
+    this._clear();
     var content = get(this, 'content');
-    if(content) { content.addArrayObserver(this); }
-    var len = content ? get(content, 'length') : 0;
+    if (!content) { return; }
+    content.addArrayObserver(this);
+    this._content = content;
+    var len = get(content, 'length');
     this.arrayDidChange(content, 0, null, len);
   }),
+
+  _clear: function() {
+    if (!this._content) { return; }
+    this._content.removeArrayObserver(this);
+    this.arrayWillChange(this._content, 0, get(this._content, 'length'));
+    this._content = null;
+  },
 
   arrayWillChange: function(array, idx, removedCount) {
     for(var i = idx; i < idx + removedCount; i++) {

--- a/addon/layers/collection.js
+++ b/addon/layers/collection.js
@@ -31,11 +31,11 @@ export default ContainerLayer.extend({
 
   _contentDidChange: Ember.observer('content', function() {
     this._clear();
-    var content = get(this, 'content');
+    const content = get(this, 'content');
     if (!content) { return; }
     content.addArrayObserver(this);
     this._content = content;
-    var len = get(content, 'length');
+    const len = get(content, 'length');
     this.arrayDidChange(content, 0, null, len);
   }),
 

--- a/addon/mixins/popup.js
+++ b/addon/mixins/popup.js
@@ -124,14 +124,16 @@ export default Ember.Mixin.create({
     this._popup.setContent(get(this, 'popupContent'));
   }),
 
-  _removePopupObservers: Ember.beforeObserver(function() {
-    if(!this._layer) { return; }
-    this._destroyPopup();
-  }, 'layer'),
-
   _addPopupObservers: Ember.observer('layer', function() {
     if(!this._layer) { return; }
     this._destroyPopup();
     this._createPopup();
-  })
+  }),
+
+  _destroyLayer() {
+    if (this._popup) {
+      this._destroyPopup();
+    }
+    this._super();
+  }
 });

--- a/addon/mixins/popup.js
+++ b/addon/mixins/popup.js
@@ -128,6 +128,7 @@ export default Ember.Mixin.create({
 
   _addPopupObservers: Ember.observer('layer', function() {
     if(!this._layer) { return; }
+    this._destroyPopup();
     this._createPopup();
   })
 });

--- a/addon/mixins/popup.js
+++ b/addon/mixins/popup.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
 
 const {
-  get,
-  run
+  get
 } = Ember;
-const { schedule } = run;
 
 /**
  * `PopupMixin` adds popup functionality to any
@@ -59,43 +57,14 @@ export default Ember.Mixin.create({
   didDestroyPopup: Ember.K,
 
   _createPopupContent() {
-    if(!get(this, 'popupViewClass')) {
-      this._popup.setContent(get(this, 'popupContent'));
-      return;
+    if(get(this, 'popupViewClass')) {
+      throw new Ember.Error('popupViewClass functionality is being replaced with Ember 2.0 compatible components and is currently disabled.');
     }
-    if(this._popupView) { this._destroyPopupContent(); }
-    let viewClass = get(this, 'popupViewClass');
-    if(Ember.typeOf(viewClass) === 'string') {
-      viewClass = get(this, 'container').lookupFactory('view:' + viewClass);
-    }
-    this._popupView = viewClass.create({
-      container: get(this, 'container'),
-      controller: get(this, 'controller'),
-      context: get(this, 'controller'),
-      content: get(this, 'content')
-    });
-    // You can't call this._popupView.replaceIn because it erroneously detects
-    // the view as an Ember View because the popup's parent map's parent view
-    // is an Ember View. So we need to trick it by calling the renderer's
-    // replace function.
-    // In Ember 1.10 we need to access renderer through constructor.
-    const renderer = this._popupView.constructor.renderer || this._popupView.renderer;
-    renderer.replaceIn(this._popupView, this._popup._contentNode);
-    this._popup.update();
-
-    // After the view has rendered, call update to ensure
-    // popup is visible with autoPan
-    schedule('afterRender', this, () => {
-      this._popup.update();
-    });
+    this._popup.setContent(get(this, 'popupContent'));
   },
 
   _destroyPopupContent() {
-    if(!get(this, 'popupViewClass')) { return; }
-    if(this._popupView) {
-      this._popupView.destroy();
-      this._popupView = null;
-    }
+    // destroy internal popup component
   },
 
   _createPopup() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-leaflet",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ember + Leaflet = Fun with maps!",
   "directories": {
     "doc": "doc",

--- a/tests/unit/layers/marker-collection-test.js
+++ b/tests/unit/layers/marker-collection-test.js
@@ -126,7 +126,7 @@ moduleForComponent('leaflet-map', 'MarkerCollectionLayer and Controller', {
       Ember.Object.create({location: null})
     ]);
 
-    controller = Ember.ArrayController.create({
+    controller = Ember.ArrayProxy.create({
       content: content
     });
     var collectionClass = MarkerCollectionLayer.extend({

--- a/tests/unit/mixins/popup-complex-view-test.js
+++ b/tests/unit/mixins/popup-complex-view-test.js
@@ -47,41 +47,44 @@ moduleForComponent('leaflet-map', 'PopupMixin (Marker with complex popupViewClas
     this.render();
   }
 });
-test('Popup is created', function(assert) {
-  assert.ok(marker._popup, 'popup is created');
-  assert.equal(marker._popup._map, null, 'popup not added until opened');
-});
 
-test('Clicking shows popup', function(assert) {
-  marker._layer.fire('click', {latlng: marker.get('location')});
-  assert.ok(!!marker._popup._map, 'marker added to map');
-  locationsEqual(assert, marker._popup._latlng, marker.get('location'));
-  assert.equal(Ember.$(marker._popup._contentNode).text(),
-    '#40,#70,', 'popup content set');
-});
+// TODO: reimplement these tests when a popupComponent is implemented
 
-test('Popup content updates', function(assert) {
-  marker._layer.fire('click', {latlng: marker.get('location')});
-  Ember.run(function() {
-    controller.set('isActivated', false);
-  });
-  assert.equal(Ember.$(marker._popup._contentNode).text(),
-    'not activated', 'popup content updated');
-  Ember.run(function() {
-    controller.set('isActivated', true);
-    controller.get('items').pushObject({number: 20});
-  });
-  assert.equal(Ember.$(marker._popup._contentNode).text(),
-    '#40,#70,#20,', 'popup content updated');
-});
+// test('Popup is created', function(assert) {
+//   assert.ok(marker._popup, 'popup is created');
+//   assert.equal(marker._popup._map, null, 'popup not added until opened');
+// });
 
-test('Closing popup destroys view', function(assert) {
-  marker._layer.fire('click', {latlng: marker.get('location')});
-  var popupView = marker._popupView;
-  assert.ok(popupView, 'popup view created');
-  Ember.run(function() {
-    component._layer.closePopup();
-  });
-  assert.equal(marker._popupView, null, 'popupView is nullified');
-  assert.equal(popupView.isDestroyed, true, 'popup view is destroyed');
-});
+// test('Clicking shows popup', function(assert) {
+//   marker._layer.fire('click', {latlng: marker.get('location')});
+//   assert.ok(!!marker._popup._map, 'marker added to map');
+//   locationsEqual(assert, marker._popup._latlng, marker.get('location'));
+//   assert.equal(Ember.$(marker._popup._contentNode).text(),
+//     '#40,#70,', 'popup content set');
+// });
+
+// test('Popup content updates', function(assert) {
+//   marker._layer.fire('click', {latlng: marker.get('location')});
+//   Ember.run(function() {
+//     controller.set('isActivated', false);
+//   });
+//   assert.equal(Ember.$(marker._popup._contentNode).text(),
+//     'not activated', 'popup content updated');
+//   Ember.run(function() {
+//     controller.set('isActivated', true);
+//     controller.get('items').pushObject({number: 20});
+//   });
+//   assert.equal(Ember.$(marker._popup._contentNode).text(),
+//     '#40,#70,#20,', 'popup content updated');
+// });
+
+// test('Closing popup destroys view', function(assert) {
+//   marker._layer.fire('click', {latlng: marker.get('location')});
+//   var popupView = marker._popupView;
+//   assert.ok(popupView, 'popup view created');
+//   Ember.run(function() {
+//     component._layer.closePopup();
+//   });
+//   assert.equal(marker._popupView, null, 'popupView is nullified');
+//   assert.equal(popupView.isDestroyed, true, 'popup view is destroyed');
+// });

--- a/tests/unit/mixins/popup-view-test.js
+++ b/tests/unit/mixins/popup-view-test.js
@@ -36,35 +36,37 @@ moduleForComponent('leaflet-map', 'PopupMixin (Marker with popupViewClass)', {
   }
 });
 
-test('Popup is created', function(assert) {
-  assert.ok(marker._popup, 'popup is created');
-  assert.equal(marker._popup._map, null, 'popup not added until opened');
-});
+// TODO: reimplement these tests when popupComponent is implemented
 
-test('Clicking shows popup', function(assert) {
-  marker._layer.fire('click', {latlng: marker.get('location')});
-  assert.ok(!!marker._popup._map, 'marker added to map');
-  locationsEqual(assert, marker._popup._latlng, marker.get('location'));
-  assert.equal(Ember.$(marker._popup._contentNode).text(),
-    'value: true', 'popup content set');
-});
+// test('Popup is created', function(assert) {
+//   assert.ok(marker._popup, 'popup is created');
+//   assert.equal(marker._popup._map, null, 'popup not added until opened');
+// });
 
-test('Popup content updates', function(assert) {
-  marker._layer.fire('click', {latlng: marker.get('location')});
-  Ember.run(function() {
-    controller.set('value', false);
-  });
-  assert.equal(Ember.$(marker._popup._contentNode).text(),
-    'value: false', 'popup content updated');
-});
+// test('Clicking shows popup', function(assert) {
+//   marker._layer.fire('click', {latlng: marker.get('location')});
+//   assert.ok(!!marker._popup._map, 'marker added to map');
+//   locationsEqual(assert, marker._popup._latlng, marker.get('location'));
+//   assert.equal(Ember.$(marker._popup._contentNode).text(),
+//     'value: true', 'popup content set');
+// });
 
-test('Closing popup destroys componente', function(assert) {
-  marker._layer.fire('click', {latlng: marker.get('location')});
-  var popupView = marker._popupView;
-  assert.ok(popupView, 'popup view created');
-  Ember.run(function() {
-    component._layer.closePopup();
-  });
-  assert.equal(marker._popupView, null, 'popupView is nullified');
-  assert.equal(popupView.isDestroyed, true, 'popup view is destroyed');
-});
+// test('Popup content updates', function(assert) {
+//   marker._layer.fire('click', {latlng: marker.get('location')});
+//   Ember.run(function() {
+//     controller.set('value', false);
+//   });
+//   assert.equal(Ember.$(marker._popup._contentNode).text(),
+//     'value: false', 'popup content updated');
+// });
+
+// test('Closing popup destroys componente', function(assert) {
+//   marker._layer.fire('click', {latlng: marker.get('location')});
+//   var popupView = marker._popupView;
+//   assert.ok(popupView, 'popup view created');
+//   Ember.run(function() {
+//     component._layer.closePopup();
+//   });
+//   assert.equal(marker._popupView, null, 'popupView is nullified');
+//   assert.equal(popupView.isDestroyed, true, 'popup view is destroyed');
+// });

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-leaflet",
   "description": "Ember + Leaflet = Fun with maps!",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "options": {
     "paths": [
       "addon",


### PR DESCRIPTION
- [x] remove beforeObserver in CollectionLayer
- [x] remove beforeObserver in ArrayPathLayer
- [x] remove beforeObserver in PopupLayer
- [x] remove all ArrayControllers
- [x] ~~remove use of Ember.View from PopupMixin~~ Removed popupViewClass functionality for now. @miguelcobain will replace with popupComponent PR!
- more?...

definitely could use help testing this in as many folks as possible's actual use cases before merging!